### PR TITLE
Add language attribute to document

### DIFF
--- a/root/src/index.html
+++ b/root/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-US">
   <head>
     <%= t.include("partials/_head.html") %>
     <link rel="stylesheet" type="text/css" href="style.css">


### PR DESCRIPTION
w3c recommends including lang attribute to assist non-text readers https://www.w3.org/International/questions/qa-lang-why.en