### PR TITLE
Paywall Script

### DIFF
--- a/root/src/js/lib/paywall.js
+++ b/root/src/js/lib/paywall.js
@@ -7,12 +7,13 @@ var paywall = function(pageId) {
 
   window.SEATIMESCO.paywall.contentMetered = true;
   window.SEATIMESCO.paywall.pageExcluded = false;
+  window.SEATIMESCO.paywall.configsPath = "https://www.seattletimes.com/wp-json/paywall/settings";
 
   window.SEATIMESCO.contentInfo.domain = "projects.seattletimes.com";
   window.SEATIMESCO.contentInfo.post_id = pageId;
-  window.SEATIMESCO.contentInfo.sections_all = 'projects';
+  window.SEATIMESCO.contentInfo.sections_all = "projects";
 
-  var paywallScript = document.createElement('script');
+  var paywallScript = document.createElement("script");
   paywallScript.async = true;
   paywallScript.defer = true;
   paywallScript.src = "https://www.seattletimes.com/wp-content/plugins/st-user-messaging/dist/st-user-messaging-paywall-bundle.js";

--- a/root/src/js/lib/paywall.js
+++ b/root/src/js/lib/paywall.js
@@ -1,0 +1,22 @@
+// pageId is a unique identifier for the current project
+var paywall = function(pageId) {
+  // Set global configs to enable the pagewall and identify the current page
+  window.SEATIMESCO = window.SEATIMESCO || {};
+  window.SEATIMESCO.paywall = window.SEATIMESCO.paywall || {};
+  window.SEATIMESCO.contentInfo = window.SEATIMESCO.contentInfo || {};
+
+  window.SEATIMESCO.paywall.contentMetered = true;
+  window.SEATIMESCO.paywall.pageExcluded = false;
+
+  window.SEATIMESCO.contentInfo.domain = "projects.seattletimes.com";
+  window.SEATIMESCO.contentInfo.post_id = pageId;
+  window.SEATIMESCO.contentInfo.sections_all = 'projects';
+
+  var paywallScript = document.createElement('script');
+  paywallScript.async = true;
+  paywallScript.defer = true;
+  paywallScript.src = "https://www.seattletimes.com/wp-content/plugins/st-user-messaging/dist/st-user-messaging-paywall-bundle.js";
+  document.head.appendChild(paywallScript);
+}
+
+module.exports = paywall;


### PR DESCRIPTION
This adds a paywall lib script to the newsapp template. Including this script will enable the Seattle Times paywall on your project by setting some config variables to `window.SEATIMESCO` and running a paywall script from seattletimes.com. The paywall module requires a unique identifier for the project it is running on. This doesn't have to correspond to a WordPress post id, it just needs to be something to identify the page view when it is stored in the paymeter log.

The ST paywall script hasn't been released yet so the configsPath and script src urls below won't work. To test change them to:
https://staging.seattletimes.com/wp-json/paywall/settings
https://staging.seattletimes.com/wp-content/plugins/st-user-messaging/dist/st-user-messaging-paywall-bundle.js