### PR TITLE
[ Prod - 9016 ] -- Add Hashtag Labs, remove Zeus

### DIFF
--- a/root/src/css/seattletimes.less
+++ b/root/src/css/seattletimes.less
@@ -188,7 +188,7 @@ h4 {
   }
 }
 
-zeus-ad {
+.htlad {
   margin-top: 1em !important;
   margin-bottom: 1em !important;
 }

--- a/root/src/index.html
+++ b/root/src/index.html
@@ -4,7 +4,11 @@
     <%= t.include("partials/_head.html", grunt.data.json) %>
     <% if (!json.project.embedded) { %>
       <%= t.include("partials/_dataLayer.html") %>
-      <script src="https://seattle-times.zeustechnology.com/main.js" async></script>
+      <link rel="preload" href="https://htlbid.com/v3/seattletimes.com/htlbid.css" as="style" />
+      <link rel="preload" href="https://htlbid.com/v3/seattletimes.com/htlbid.js" as="script" />
+      <link rel='stylesheet' tvpe='text/css' href='https://htlbid.com/v3/seattletimes.com/htlbid.css' />
+
+      <script src="https://htlbid.com/v3/seattletimes.com/htlbid.js" async></script>
       <script src="https://www.seattletimes.com/wp-content/plugins/st-advertising/dist/st-projects-bundle.js" async></script>
     <% } %>
     <% if (json.project.production && !json.project.embedded) { %>

--- a/root/src/index.html
+++ b/root/src/index.html
@@ -8,7 +8,7 @@
       <link rel="preload" href="https://htlbid.com/v3/seattletimes.com/htlbid.js" as="script" />
       <link rel='stylesheet' tvpe='text/css' href='https://htlbid.com/v3/seattletimes.com/htlbid.css' />
 
-      <script src="https://htlbid.com/v3/seattletimes.com/htlbid.js" async></script>
+      <script src="https://htlbid.com/v3/seattletimes.com/htlbid.js" class="optanon-category-SN" async></script>
       <script src="https://www.seattletimes.com/wp-content/plugins/st-advertising/dist/st-projects-bundle.js" async></script>
     <% } %>
     <% if (json.project.production && !json.project.embedded) { %>

--- a/root/src/partials/_ad.html
+++ b/root/src/partials/_ad.html
@@ -1,5 +1,7 @@
 <!--  Each code can only be used once per page -->
-<% var adCodes = ["zeus_top", "zeus_bottom", "zeus_middle", "zeus_body8a", "zeus_body9a", "zeus_body11a", "zeus_body12a", "zeus_body5a", "zeus_body6a","zeus_body2a"];
-var chosenAd = adCodes[(number - 1)]; %>
+<% const adCodes = ["htlad-top", "htlad-middle", "htlad-bottom", "htlad-body8a", "htlad-body9a", "htlad-body11a", "htlad-body12a", "htlad-body5a", "htlad-body6a","htlad-body2a"];
+const chosenAd = adCodes[(number - 1)]; %>
 
-<zeus-ad id='<%= chosenAd %>' width="100%;"></zeus-ad>
+<% const adSlotName = chosenAd.replace('htlad-', ''); %>
+
+<div class="htlad <%= chosenAd %>" style="width:100%" data-unit="/81279359/seattletimes.com/default" data-targeting="{'pos':['<%= adSlotName %>']}"></div>


### PR DESCRIPTION
This updates the primary news app template, removing Zeus and adding in support for Hashtag labs.
In order for this to be successful, the bundled `st-projects-bundle` that all the newsapps request has been updated for support with Hashtag labs and is not on production as of just yet.
Once we have this on a ST test environment we can test a news app update.
The production URL will not change.
https://www.seattletimes.com/wp-content/plugins/st-advertising/dist/st-projects-bundle.js

Any apps rebuilt or newly built apps will get the updated build.
There are three files that needed attention.
* root/src/css/seattletimes.less
* root/src/index.html
* root/src/partials/_ad.html

It has been determined that an older project that still requests Zeus is acceptable and known that no ads will load.
The content is expected to load with no ads when the app has not been rebuilt.

I was given this repo and live URL as examples to work with.

Repo: https://github.com/seattletimes/ph-promises-made-kept-2022
Page: https://projects.seattletimes.com/2022/seattle-king-county-homeless-promises-outcomes/